### PR TITLE
Fix auth check for chat API

### DIFF
--- a/src/app/api/chat/route.js
+++ b/src/app/api/chat/route.js
@@ -1,5 +1,7 @@
 // src/app/api/chat/route.js
 import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]/route";
 import prisma from "@/lib/prisma";
 import OpenAI from "openai";
 
@@ -7,13 +9,20 @@ const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 export async function POST(req) {
   try {
-    const { model, prompt, userId } = await req.json();
-    if (!model || !prompt || !userId) {
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { model, prompt } = await req.json();
+    if (!model || !prompt) {
       return NextResponse.json(
-        { error: "Missing model, prompt or userId" },
+        { error: "Missing model or prompt" },
         { status: 400 }
       );
     }
+
+    const userId = session.user.id;
 
     let responseText;
     try {

--- a/src/app/chat/page.js
+++ b/src/app/chat/page.js
@@ -37,7 +37,6 @@ export default function ChatPage() {
       body: JSON.stringify({
         model,
         prompt,
-        userId: session.user.id,
       }),
     });
 


### PR DESCRIPTION
## Summary
- secure chat API by validating the current session instead of trusting the user ID from the request
- update chat page to no longer send `userId`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844cd1d30a88321b341eed4ae6c090f